### PR TITLE
Add Wing Commander 3 IFF decoder library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.10)
+project(wc_iff_loader CXX)
+
+add_library(wc_iff
+    src/IFFReader.cpp
+    src/WC3Decoder.cpp
+)
+
+target_include_directories(wc_iff PUBLIC include)
+set_target_properties(wc_iff PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
+
+add_executable(test_wc_iff test/test_wc_iff.cpp)
+target_link_libraries(test_wc_iff wc_iff)
+
+enable_testing()
+add_test(NAME test_wc_iff COMMAND test_wc_iff)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # wc-iff-loader
-Wing Commander IFF Loader
+
+A small C++ library for decoding EA/Origin IFF files as used by Wing Commander 3.
+The library provides a generic IFF parser and a simple decoder that extracts
+3D model data (vertices and faces) from WC3 model files.
+
+## Building
+
+This project uses CMake:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+ctest
+```
+
+The example test generates a minimal WC3 style IFF file and verifies that the
+library decodes it correctly.

--- a/include/wc_iff_loader/IFFReader.h
+++ b/include/wc_iff_loader/IFFReader.h
@@ -1,0 +1,36 @@
+#ifndef WC_IFF_LOADER_IFFREADER_H
+#define WC_IFF_LOADER_IFFREADER_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <istream>
+
+namespace wc_iff_loader {
+
+struct IffChunk {
+    std::string id;                     // Chunk ID (e.g. "FORM", "VERT")
+    uint32_t size = 0;                  // Size of chunk data
+    std::string type;                   // FORM/LIST type
+    std::vector<uint8_t> data;          // Raw data for leaf chunks
+    std::vector<IffChunk> children;     // Child chunks for FORM/LIST/CAT
+};
+
+class IFFReader {
+public:
+    // Load an IFF file from disk. Returns true on success.
+    bool load(const std::string& path);
+
+    // Access parsed root chunk
+    const IffChunk& root() const { return rootChunk; }
+
+private:
+    IffChunk rootChunk;
+    bool parseChunk(std::istream& is, IffChunk& parent, uint32_t size);
+    static uint32_t readU32BE(std::istream& is);
+    static float readF32BE(std::istream& is);
+};
+
+} // namespace wc_iff_loader
+
+#endif // WC_IFF_LOADER_IFFREADER_H

--- a/include/wc_iff_loader/WC3Decoder.h
+++ b/include/wc_iff_loader/WC3Decoder.h
@@ -1,0 +1,25 @@
+#ifndef WC_IFF_LOADER_WC3DECODER_H
+#define WC_IFF_LOADER_WC3DECODER_H
+
+#include "wc_iff_loader/IFFReader.h"
+#include <vector>
+
+namespace wc_iff_loader {
+
+struct Vertex { float x, y, z; };
+struct Face { uint16_t v1, v2, v3; };
+
+struct Model {
+    std::vector<Vertex> vertices;
+    std::vector<Face> faces;
+};
+
+class WC3Decoder {
+public:
+    // Decode WC3 model from root FORM chunk
+    static Model decode(const IffChunk& root);
+};
+
+} // namespace wc_iff_loader
+
+#endif // WC_IFF_LOADER_WC3DECODER_H

--- a/src/IFFReader.cpp
+++ b/src/IFFReader.cpp
@@ -1,0 +1,83 @@
+#include "wc_iff_loader/IFFReader.h"
+#include <fstream>
+#include <cstring>
+#include <stdexcept>
+
+namespace wc_iff_loader {
+
+static bool isContainer(const std::string& id) {
+    return id == "FORM" || id == "LIST" || id == "CAT ";
+}
+
+uint32_t IFFReader::readU32BE(std::istream& is) {
+    uint8_t b[4];
+    is.read(reinterpret_cast<char*>(b), 4);
+    return (static_cast<uint32_t>(b[0]) << 24) |
+           (static_cast<uint32_t>(b[1]) << 16) |
+           (static_cast<uint32_t>(b[2]) << 8)  |
+           static_cast<uint32_t>(b[3]);
+}
+
+float IFFReader::readF32BE(std::istream& is) {
+    uint32_t u = readU32BE(is);
+    float f;
+    std::memcpy(&f, &u, sizeof(f));
+    return f;
+}
+
+bool IFFReader::load(const std::string& path) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file)
+        return false;
+
+    char id[4];
+    file.read(id, 4);
+    if (file.gcount() != 4 || std::string(id,4) != "FORM")
+        return false;
+
+    rootChunk.id = "FORM";
+    rootChunk.size = readU32BE(file);
+    char type[4];
+    file.read(type, 4);
+    rootChunk.type.assign(type, 4);
+
+    if (!parseChunk(file, rootChunk, rootChunk.size - 4))
+        return false;
+
+    return true;
+}
+
+bool IFFReader::parseChunk(std::istream& is, IffChunk& parent, uint32_t size) {
+    uint32_t bytesRead = 0;
+    while (bytesRead < size) {
+        char id[4];
+        is.read(id, 4);
+        if (is.gcount() != 4)
+            return false;
+        uint32_t chunkSize = readU32BE(is);
+        IffChunk chunk;
+        chunk.id.assign(id, 4);
+        chunk.size = chunkSize;
+        bytesRead += 8 + chunkSize + (chunkSize & 1);
+
+        if (isContainer(chunk.id)) {
+            char type[4];
+            is.read(type, 4);
+            chunk.type.assign(type, 4);
+            if (!parseChunk(is, chunk, chunkSize - 4))
+                return false;
+        } else {
+            chunk.data.resize(chunkSize);
+            is.read(reinterpret_cast<char*>(chunk.data.data()), chunkSize);
+        }
+
+        if (chunkSize & 1)
+            is.get(); // skip pad
+
+        parent.children.push_back(std::move(chunk));
+    }
+    return true;
+}
+
+} // namespace wc_iff_loader
+

--- a/src/WC3Decoder.cpp
+++ b/src/WC3Decoder.cpp
@@ -1,0 +1,63 @@
+#include "wc_iff_loader/WC3Decoder.h"
+#include <cstring>
+
+namespace wc_iff_loader {
+
+static const IffChunk* findChunk(const IffChunk& parent, const std::string& id) {
+    for (const auto& c : parent.children) {
+        if (c.id == id)
+            return &c;
+    }
+    return nullptr;
+}
+
+Model WC3Decoder::decode(const IffChunk& root) {
+    Model model;
+    const IffChunk* vert = findChunk(root, "VERT");
+    const IffChunk* face = findChunk(root, "FACE");
+    if (!vert || !face)
+        return model;
+
+    std::istream vstream(nullptr);
+    // parse vertices
+    {
+        const std::vector<uint8_t>& data = vert->data;
+        if (data.size() < 4)
+            return model;
+        size_t offset = 0;
+        uint32_t count = (data[offset] << 24) | (data[offset+1] << 16) | (data[offset+2] << 8) | data[offset+3];
+        offset += 4;
+        model.vertices.resize(count);
+        for (uint32_t i=0; i<count; ++i) {
+            uint32_t bx = (data[offset] << 24) | (data[offset+1] << 16) | (data[offset+2] << 8) | data[offset+3]; offset += 4;
+            uint32_t by = (data[offset] << 24) | (data[offset+1] << 16) | (data[offset+2] << 8) | data[offset+3]; offset += 4;
+            uint32_t bz = (data[offset] << 24) | (data[offset+1] << 16) | (data[offset+2] << 8) | data[offset+3]; offset += 4;
+            float fx, fy, fz;
+            std::memcpy(&fx, &bx, sizeof(float));
+            std::memcpy(&fy, &by, sizeof(float));
+            std::memcpy(&fz, &bz, sizeof(float));
+            model.vertices[i] = {fx, fy, fz};
+        }
+    }
+
+    // parse faces
+    {
+        const std::vector<uint8_t>& data = face->data;
+        if (data.size() < 4)
+            return model;
+        size_t offset = 0;
+        uint32_t count = (data[offset] << 24) | (data[offset+1] << 16) | (data[offset+2] << 8) | data[offset+3];
+        offset += 4;
+        model.faces.resize(count);
+        for (uint32_t i=0; i<count; ++i) {
+            uint16_t i1 = (data[offset] << 8) | data[offset+1]; offset += 2;
+            uint16_t i2 = (data[offset] << 8) | data[offset+1]; offset += 2;
+            uint16_t i3 = (data[offset] << 8) | data[offset+1]; offset += 2;
+            model.faces[i] = {i1, i2, i3};
+        }
+    }
+
+    return model;
+}
+
+} // namespace wc_iff_loader

--- a/test/test_wc_iff.cpp
+++ b/test/test_wc_iff.cpp
@@ -1,0 +1,74 @@
+#include "wc_iff_loader/IFFReader.h"
+#include "wc_iff_loader/WC3Decoder.h"
+#include <cassert>
+#include <fstream>
+#include <cstring>
+#include <vector>
+
+using namespace wc_iff_loader;
+
+static void writeU32BE(std::vector<uint8_t>& buf, uint32_t v) {
+    buf.push_back((v >> 24) & 0xFF);
+    buf.push_back((v >> 16) & 0xFF);
+    buf.push_back((v >> 8) & 0xFF);
+    buf.push_back(v & 0xFF);
+}
+
+static void writeF32BE(std::vector<uint8_t>& buf, float f) {
+    uint32_t u;
+    std::memcpy(&u, &f, sizeof(u));
+    writeU32BE(buf, u);
+}
+
+static void writeU16BE(std::vector<uint8_t>& buf, uint16_t v) {
+    buf.push_back((v >> 8) & 0xFF);
+    buf.push_back(v & 0xFF);
+}
+
+int main() {
+    std::vector<uint8_t> file;
+    // Root FORM header
+    file.insert(file.end(), {'F','O','R','M'});
+    // Placeholder size
+    writeU32BE(file, 0);
+    // Type
+    file.insert(file.end(), {'W','C','3','M'});
+
+    std::vector<uint8_t> vert;
+    writeU32BE(vert, 3); // num vertices
+    writeF32BE(vert, 1.0f); writeF32BE(vert, 0.0f); writeF32BE(vert, 0.0f);
+    writeF32BE(vert, 0.0f); writeF32BE(vert, 1.0f); writeF32BE(vert, 0.0f);
+    writeF32BE(vert, 0.0f); writeF32BE(vert, 0.0f); writeF32BE(vert, 1.0f);
+    std::vector<uint8_t> face;
+    writeU32BE(face, 1); // num faces
+    writeU16BE(face, 0); writeU16BE(face, 1); writeU16BE(face, 2);
+
+    auto startSize = file.size();
+    file.insert(file.end(), {'V','E','R','T'});
+    writeU32BE(file, vert.size());
+    file.insert(file.end(), vert.begin(), vert.end());
+    if (vert.size() & 1) file.push_back(0);
+
+    file.insert(file.end(), {'F','A','C','E'});
+    writeU32BE(file, face.size());
+    file.insert(file.end(), face.begin(), face.end());
+    if (face.size() & 1) file.push_back(0);
+
+    uint32_t formSize = file.size() - 8; // exclude 'FORM' and size field
+    file[4] = (formSize >> 24) & 0xFF;
+    file[5] = (formSize >> 16) & 0xFF;
+    file[6] = (formSize >> 8) & 0xFF;
+    file[7] = formSize & 0xFF;
+
+    std::ofstream ofs("test.iff", std::ios::binary);
+    ofs.write(reinterpret_cast<const char*>(file.data()), file.size());
+
+    IFFReader reader;
+    ofs.close();
+    assert(reader.load("test.iff"));
+
+    Model model = WC3Decoder::decode(reader.root());
+    assert(model.vertices.size() == 3);
+    assert(model.faces.size() == 1);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement IFFReader for parsing EA/Origin IFF files
- add WC3Decoder to extract model data
- provide a small test that generates an example WC3 model
- document build instructions

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68653611aad483309f098734d0d112a0